### PR TITLE
Update node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - 20
-          - 21
+          - 22
+          - 23
         os:
           - macos-latest
           - ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   FORCE_COLOR: 3
-  NODE_VERSION: 20
+  NODE_VERSION: 22
 
 jobs:
   publish:


### PR DESCRIPTION
We're using node 22 & 23 now, so time to bump the versions we build on over here.