### PR TITLE
Build environment updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
+          - ubuntu-24.04-arm
+          - windows-11-arm
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
- Remove old versions of node we don't support
- Add node v24 which we do support
- Build on arm vms